### PR TITLE
Allows source install from current directory

### DIFF
--- a/arm_cli/self/self.py
+++ b/arm_cli/self/self.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 
 import click
+from click.core import ParameterSource
 
 
 @click.group()
@@ -14,14 +15,17 @@ def self():
 @self.command()
 @click.option(
     "--source",
-    default=".",
+    default=None,
     type=click.Path(exists=True),
-    help="Install from a local source path",
-    show_default=True,
+    help="Install from a local source path (defaults to current directory if specified without value)",
 )
 @click.option("-f", "--force", is_flag=True, help="Skip confirmation prompts")
-def update(source, force):
+@click.pass_context
+def update(ctx, source, force):
     """Update arm-cli from PyPI or source"""
+    if source is None and ctx.get_parameter_source("source") == ParameterSource.COMMANDLINE:
+        source = "."
+
     if source:
         print(f"Installing arm-cli from source at {source}...")
 


### PR DESCRIPTION
Allows installation from the current directory when the --source flag is specified without a value. Previously, specifying `--source` without a value would not default to the current directory, requiring the user to explicitly provide a path. This change makes the behavior more intuitive.